### PR TITLE
Exclude current post in posts widget (second attempt)

### DIFF
--- a/inc/widgets/post-list.php
+++ b/inc/widgets/post-list.php
@@ -62,13 +62,13 @@ class ct_mission_news_post_list extends WP_Widget {
 		);
 		
 		/** @var $post WP_Post */
-        global $post;
-
-        // Exclude current post if exists
-        if ($post) {
-            $query_args['post__not_in'] = [$post->ID];
-        }
-
+		global $post;
+		
+		// Exclude current post if exists
+		if ($post) {
+			$query_args['post__not_in'] = [$post->ID];
+		}
+		
 		// If using posts in either a category or a tag
 		if ( $instance['use_category'] == 'yes' && $instance['use_tag'] == 'yes' && $instance['relationship'] == 'OR' ) {
 			$query_args['tax_query'] = array(

--- a/inc/widgets/post-list.php
+++ b/inc/widgets/post-list.php
@@ -60,6 +60,15 @@ class ct_mission_news_post_list extends WP_Widget {
 			'post_type'      => 'post',
 			'post_status'    => 'publish'
 		);
+		
+		/** @var $post WP_Post */
+        global $post;
+
+        // Exclude current post if exists
+        if ($post) {
+            $query_args['post__not_in'] = [$post->ID];
+        }
+
 		// If using posts in either a category or a tag
 		if ( $instance['use_category'] == 'yes' && $instance['use_tag'] == 'yes' && $instance['relationship'] == 'OR' ) {
 			$query_args['tax_query'] = array(


### PR DESCRIPTION
Hello, @BenSibley !

I had added the logic for excluding current post in Posts list widget. It was done for SEO (no self-linking) but anyway the page looks better when no current post is in the sidebar. Maybe we may create an option for that, it's up to you.

Have a nice day!